### PR TITLE
drop the 3 way handshake ack

### DIFF
--- a/c/minecraft_filter.c
+++ b/c/minecraft_filter.c
@@ -308,7 +308,7 @@ __s32 minecraft_filter(struct xdp_md *ctx)
 
         // we can drop original ack from the tcp 3 way handshake
         // the backend will accept the first minecraft data packet as the ack of the 3 way handshake
-        // thats an elegent way to only let the backend accept connections that have a mc handshake in it.
+        // that's an elegant way to only let the backend accept connections that have a mc handshake in it.
         goto drop;
     }
 

--- a/c/minecraft_filter.c
+++ b/c/minecraft_filter.c
@@ -151,7 +151,7 @@ __s32 minecraft_filter(struct xdp_md *ctx)
         return XDP_DROP;
     }
 
-    if (eth->h_proto != bpf_ntohs(ETH_P_IP))
+    if (eth->h_proto != bpf_htons(ETH_P_IP))
     {
         return XDP_PASS;
     }


### PR DESCRIPTION
We can drop the ack of the 3 way handshake, and by doing so we ensure the tcp stack of linux will see the minecraft packet data tcp packets as first packets with the ack flag set, the backend tcp stack will now only accept connections that have send at least an minecraft handshake packet