### PR TITLE
Remove redundant data_end bounds checks from payload inspection

### DIFF
--- a/c/common.h
+++ b/c/common.h
@@ -25,25 +25,21 @@
 
 
 // Checks bounds and returns 0 if out of bounds (does NOT increment ptr)
-#define CHECK_BOUNDS_OR_RETURN(ptr, n, pend, dend)          \
+// pend must be validated against data_end before use (see minecraft_filter.c)
+#define CHECK_BOUNDS_OR_RETURN(ptr, n, pend)          \
     do                                                      \
     {                                                       \
-        if ((void *)(ptr) + (n) > (const void *)(dend))           \
-            return 0;                                       \
-        barrier_var(ptr);                                   \
         if ((void *)(ptr) + (n) > (const void *)(pend))           \
             return 0;                                       \
         barrier_var(ptr);                                   \
     } while (0)
 
 // checks bounds. if bad, returns 0. if good, increments ptr.
-// usage: READ_OR_RETURN(reader_index, 2, payload_end, data_end);
-#define READ_OR_RETURN(ptr, n, pend, dend)       \
+// pend must be validated against data_end before use (see minecraft_filter.c)
+// usage: READ_OR_RETURN(reader_index, 2, payload_end);
+#define READ_OR_RETURN(ptr, n, pend)       \
     do                                           \
     {                                            \
-        if ((void *)(ptr) + (n) > (const void *)(dend)) \
-            return 0;                            \
-        barrier_var(ptr);                        \
         if ((void *)(ptr) + (n) > (const void *)(pend)) \
             return 0;                            \
         barrier_var(ptr);                        \
@@ -59,12 +55,10 @@
      ((__u32)(n) <= 0xFFFFFFF) ? 4 : 5)
 
 // reads a value into 'dest' and increments 'ptr', or returns 0 if OOB
-#define READ_VAL_OR_RETURN(dest, ptr, pend, dend)           \
+// pend must be validated against data_end before use (see minecraft_filter.c)
+#define READ_VAL_OR_RETURN(dest, ptr, pend)           \
     do                                                      \
     {                                                       \
-        if ((void *)(ptr) + sizeof(dest) > (const void *)(dend))  \
-            return 0;                                       \
-        barrier_var(ptr);                                   \
         if ((void *)(ptr) + sizeof(dest) > (const void *)(pend))  \
             return 0;                                       \
         barrier_var(ptr);                                   \
@@ -89,20 +83,22 @@
     } while (0)
 
 // reads a varint into 'dest_struct', increments 'ptr', or returns 0 on failure.
-#define VARINT_OR_DIE(dest_struct, ptr, pend, dend) \
+// pend must be validated against data_end before use (see minecraft_filter.c)
+#define VARINT_OR_DIE(dest_struct, ptr, pend) \
     do                                                                 \
     {                                                                  \
-        dest_struct = read_varint_sized(ptr, pend, 5, dend);   \
+        dest_struct = read_varint_sized(ptr, pend, 5);   \
         if (!(dest_struct).bytes)                                      \
             return 0;                                                  \
         (ptr) += (dest_struct).bytes;                                  \
         barrier_var(ptr);                                              \
     } while (0)
 
-#define MAX_VARINT_OR_DIE(dest_struct, ptr, pend, dend, max) \
+// pend must be validated against data_end before use (see minecraft_filter.c)
+#define MAX_VARINT_OR_DIE(dest_struct, ptr, pend, max) \
     do                                                                 \
     {                                                                  \
-        dest_struct = read_varint_sized(ptr, pend, max, dend);   \
+        dest_struct = read_varint_sized(ptr, pend, max);   \
         if (!(dest_struct).bytes)                                      \
             return 0;                                                  \
         (ptr) += (dest_struct).bytes;                                  \

--- a/c/minecraft_filter.c
+++ b/c/minecraft_filter.c
@@ -259,6 +259,11 @@ __s32 minecraft_filter(struct xdp_md *ctx)
 
     // total length of ip packet
     const __u16 ip_tot_len = bpf_ntohs(ip->tot_len);
+    // guard against underflow: if ip_tot_len is too small the subtraction wraps to a large u16
+    if (ip_tot_len < (ip->ihl * 4) + tcp_hdr_len)
+    {
+        goto drop;
+    }
     // total ip - ip header - tcp header = length of tcp payload
     const __u16 tcp_payload_len = ip_tot_len - (ip->ihl * 4) - tcp_hdr_len;
     // tcp payload end = start + length

--- a/c/minecraft_filter.c
+++ b/c/minecraft_filter.c
@@ -264,7 +264,9 @@ __s32 minecraft_filter(struct xdp_md *ctx)
     // tcp payload end = start + length
     const __u8 *tcp_payload_end = tcp_payload + tcp_payload_len;
 
-    // tcp packet is split in multiple ethernet frames, we don't support that
+    // tcp payload end must be within packet bounds
+    // this single check satisfies the verifier for all subsequent payload_end bounds checks
+    // since payload_end <= data_end, checking ptr <= payload_end implies ptr <= data_end
     if (tcp_payload_end > (__u8 *)data_end)
     {
         goto drop;
@@ -320,7 +322,7 @@ __s32 minecraft_filter(struct xdp_md *ctx)
             // returns the next state
             // if the login data or motd request is included in the same tcp data as the handshake
             // the tcp_payload reader index will be updated to the next position
-            __s32 next_state = inspect_handshake(tcp_payload, tcp_payload_end, &initial_state->protocol, data_end, &tcp_payload);
+            __s32 next_state = inspect_handshake(tcp_payload, tcp_payload_end, &initial_state->protocol, &tcp_payload);
             // if the first packet has invalid length, we can block it
             // even with retransmission this len should always be valid‚
             if (!next_state)
@@ -346,7 +348,7 @@ __s32 minecraft_filter(struct xdp_md *ctx)
         }
         if (state == AWAIT_STATUS_REQUEST)
         read_status: {
-            if (!inspect_status_request(tcp_payload, tcp_payload_end, data_end))
+            if (!inspect_status_request(tcp_payload, tcp_payload_end))
             {
                 goto drop;
             }
@@ -355,7 +357,7 @@ __s32 minecraft_filter(struct xdp_md *ctx)
         }
         if (state == AWAIT_PING)
         {
-            if (!inspect_ping_request(tcp_payload, tcp_payload_end, data_end))
+            if (!inspect_ping_request(tcp_payload, tcp_payload_end))
             {
                 goto drop;
             }
@@ -365,7 +367,7 @@ __s32 minecraft_filter(struct xdp_md *ctx)
         if (state == AWAIT_LOGIN)
         read_login: {
         
-            if (!inspect_login_packet(tcp_payload, tcp_payload_end, initial_state->protocol, data_end))
+            if (!inspect_login_packet(tcp_payload, tcp_payload_end, initial_state->protocol))
             {
                 goto drop;
             }

--- a/c/minecraft_helper.h
+++ b/c/minecraft_helper.h
@@ -70,13 +70,11 @@ static __always_inline struct varint_value varint(__s32 value, __u32 bytes)
 _Static_assert(sizeof(struct varint_value) == 8, "varint_value size mismatch!");
 
 // Reads one varint byte, checks bounds, returns result if done, or continues
-#define VARINT_BYTE(ptr, pend, dend, max, idx, shift, result)   \
+// pend must be validated against data_end before use (see minecraft_filter.c)
+#define VARINT_BYTE(ptr, pend, max, idx, shift, result)   \
     do {                                                         \
         if ((max) < (idx))                                       \
             goto error;                                          \
-        if ((const void *)(ptr) + 1 > (const void *)(dend))                  \
-            goto error;                                          \
-        barrier_var(ptr);                                        \
         if ((const void *)(ptr) + 1 > (const void *)(pend))                  \
             goto error;                                          \
         barrier_var(ptr);                                        \
@@ -86,15 +84,16 @@ _Static_assert(sizeof(struct varint_value) == 8, "varint_value size mismatch!");
             return varint((result), (idx));                      \
     } while (0)
 
-static __always_inline struct varint_value read_varint_sized(__u8 *start, const __u8 *payload_end, const __u8 max_size, const void *data_end)
+// pend must be validated against data_end before use (see minecraft_filter.c)
+static __always_inline struct varint_value read_varint_sized(__u8 *start, const __u8 *payload_end, const __u8 max_size)
 {
     __s32 result = 0;
 
-    VARINT_BYTE(start, payload_end, data_end, max_size, 1, 0, result);
-    VARINT_BYTE(start, payload_end, data_end, max_size, 2, 7, result);
-    VARINT_BYTE(start, payload_end, data_end, max_size, 3, 14, result);
-    VARINT_BYTE(start, payload_end, data_end, max_size, 4, 21, result);
-    VARINT_BYTE(start, payload_end, data_end, max_size, 5, 28, result);
+    VARINT_BYTE(start, payload_end, max_size, 1, 0, result);
+    VARINT_BYTE(start, payload_end, max_size, 2, 7, result);
+    VARINT_BYTE(start, payload_end, max_size, 3, 14, result);
+    VARINT_BYTE(start, payload_end, max_size, 4, 21, result);
+    VARINT_BYTE(start, payload_end, max_size, 5, 28, result);
 
 error:
     return varint(0, 0);

--- a/c/minecraft_networking.h
+++ b/c/minecraft_networking.h
@@ -7,84 +7,87 @@
 #include "common.h"
 
 // checks if the packet contains a valid ping request
-static __always_inline __u8 inspect_ping_request(__u8 *start, const __u8 *payload_end, const void *data_end)
+// payload_end must be validated against data_end before calling
+static __always_inline __u8 inspect_ping_request(__u8 *start, const __u8 *payload_end)
 {
     struct varint_value varint;
 
     // max 9 bytes
-    MAX_VARINT_OR_DIE(varint, start, payload_end, data_end, VARINT_SIZE(0x09));
+    MAX_VARINT_OR_DIE(varint, start, payload_end, VARINT_SIZE(0x09));
     ASSERT_OR_RETURN(varint.value == 0x09);
 
     // packet id
-    MAX_VARINT_OR_DIE(varint, start, payload_end, data_end, VARINT_SIZE(0x01));
+    MAX_VARINT_OR_DIE(varint, start, payload_end, VARINT_SIZE(0x01));
     ASSERT_OR_RETURN(varint.value == 0x01);
 
     __u64 timestamp;
-    READ_VAL_OR_RETURN(timestamp, start, payload_end, data_end);
+    READ_VAL_OR_RETURN(timestamp, start, payload_end);
     return start == payload_end;
 }
 
 // checks if the packet contains a valid status request
-static __always_inline __u8 inspect_status_request(__u8 *start, const __u8 *payload_end, const void *data_end)
+// payload_end must be validated against data_end before calling
+static __always_inline __u8 inspect_status_request(__u8 *start, const __u8 *payload_end)
 {
     struct varint_value varint;
 
     // max 1 byte
-    MAX_VARINT_OR_DIE(varint, start, payload_end, data_end, VARINT_SIZE(0x01));
+    MAX_VARINT_OR_DIE(varint, start, payload_end, VARINT_SIZE(0x01));
     ASSERT_OR_RETURN(varint.value == 0x01);
 
     // packet id
-    MAX_VARINT_OR_DIE(varint, start, payload_end, data_end, VARINT_SIZE(0x00));
+    MAX_VARINT_OR_DIE(varint, start, payload_end, VARINT_SIZE(0x00));
     ASSERT_OR_RETURN(varint.value == 0x00);
 
     return start == payload_end;
 }
 
 // checks if the packet contains a valid login request
+// payload_end must be validated against data_end before calling
 // see https://github.com/SpigotMC/BungeeCord/blob/master/protocol/src/main/java/net/md_5/bungee/protocol/packet/LoginRequest.java
-static __always_inline __u8 inspect_login_packet(__u8 *reader_index, const __u8 *payload_end, __s32 protocol_version, const void *data_end)
+static __always_inline __u8 inspect_login_packet(__u8 *reader_index, const __u8 *payload_end, __s32 protocol_version)
 {
     // length of the packet
     struct varint_value varint;
 
     // len 3 bytes varint max
-    MAX_VARINT_OR_DIE(varint, reader_index, payload_end, data_end, VARINT_SIZE((PACKET_ID_MAX + LOGIN_DATA_MAX)));
+    MAX_VARINT_OR_DIE(varint, reader_index, payload_end, VARINT_SIZE((PACKET_ID_MAX + LOGIN_DATA_MAX)));
     ASSERT_IN_RANGE(varint.value, PACKET_ID_MIN + LOGIN_DATA_MIN, PACKET_ID_MAX + LOGIN_DATA_MAX);
 
     // packet id
-    MAX_VARINT_OR_DIE(varint, reader_index, payload_end, data_end, VARINT_SIZE(0x00));
+    MAX_VARINT_OR_DIE(varint, reader_index, payload_end, VARINT_SIZE(0x00));
     ASSERT_OR_RETURN(varint.value == 0x00);
 
     // username length
-    MAX_VARINT_OR_DIE(varint, reader_index, payload_end, data_end, VARINT_SIZE(LOGIN_NAME_DATA_MAX));
+    MAX_VARINT_OR_DIE(varint, reader_index, payload_end, VARINT_SIZE(LOGIN_NAME_DATA_MAX));
     // bounce check, invalid username
     ASSERT_IN_RANGE(varint.value, LOGIN_NAME_DATA_MIN, LOGIN_NAME_DATA_MAX);
     // skip the username data
-    READ_OR_RETURN(reader_index, varint.value, payload_end, data_end);
+    READ_OR_RETURN(reader_index, varint.value, payload_end);
 
     // 1_19                                          1_19_3
     if (protocol_version >= 759 && protocol_version < 761)
     {
         __u8 has_public_key;
-        READ_VAL_OR_RETURN(has_public_key, reader_index, payload_end, data_end);
+        READ_VAL_OR_RETURN(has_public_key, reader_index, payload_end);
         if (has_public_key)
         {
             // public key length
-            READ_OR_RETURN(reader_index, 8, payload_end, data_end);
+            READ_OR_RETURN(reader_index, 8, payload_end);
 
             // login key
-            MAX_VARINT_OR_DIE(varint, reader_index, payload_end, data_end, VARINT_SIZE(LOGIN_KEY_MAX));
+            MAX_VARINT_OR_DIE(varint, reader_index, payload_end, VARINT_SIZE(LOGIN_KEY_MAX));
             // assert reasonable size
             ASSERT_IN_RANGE(varint.value, LOGIN_KEY_MIN, LOGIN_KEY_MAX);
             // skip login key
-            READ_OR_RETURN(reader_index, varint.value, payload_end, data_end);
+            READ_OR_RETURN(reader_index, varint.value, payload_end);
 
             // signaturey length
-            MAX_VARINT_OR_DIE(varint, reader_index, payload_end, data_end, VARINT_SIZE(LOGIN_SIGNATURE_MAX));
+            MAX_VARINT_OR_DIE(varint, reader_index, payload_end, VARINT_SIZE(LOGIN_SIGNATURE_MAX));
             // assert reasonable size
             ASSERT_IN_RANGE(varint.value, LOGIN_SIGNATURE_MIN, LOGIN_SIGNATURE_MAX);
             // skip signature
-            READ_OR_RETURN(reader_index, varint.value, payload_end, data_end);
+            READ_OR_RETURN(reader_index, varint.value, payload_end);
         }
     }
     //  1_19_1
@@ -94,16 +97,16 @@ static __always_inline __u8 inspect_login_packet(__u8 *reader_index, const __u8 
         if (protocol_version >= 764)
         {
             // check space for uuid
-            READ_OR_RETURN(reader_index, 16, payload_end, data_end);
+            READ_OR_RETURN(reader_index, 16, payload_end);
         }
         else
         {
             // check space for uuid and boolean
             __u8 has_uuid;
-            READ_VAL_OR_RETURN(has_uuid, reader_index, payload_end, data_end);
+            READ_VAL_OR_RETURN(has_uuid, reader_index, payload_end);
             if (has_uuid)
             {
-                READ_OR_RETURN(reader_index, 16, payload_end, data_end);
+                READ_OR_RETURN(reader_index, 16, payload_end);
             }
         }
     }
@@ -112,11 +115,12 @@ static __always_inline __u8 inspect_login_packet(__u8 *reader_index, const __u8 
 }
 
 // check for valid handshake packet
+// payload_end must be validated against data_end before calling
 // note: it happens that the handshake and login or status request are in the same packet,
 // so we have to check for both cases here. this can also happen after retransmission.
-static __always_inline __s32 inspect_handshake(__u8 *reader_index, const __u8 *payload_end, __s32 *protocol_version, const void *data_end, __u8 **current_reader_index)
+static __always_inline __s32 inspect_handshake(__u8 *reader_index, const __u8 *payload_end, __s32 *protocol_version, __u8 **current_reader_index)
 {
-    CHECK_BOUNDS_OR_RETURN(reader_index, 1, payload_end, data_end);
+    CHECK_BOUNDS_OR_RETURN(reader_index, 1, payload_end);
     // check for legacy ping
     if (reader_index[0] == (__u8)0xFE)
     {
@@ -125,23 +129,23 @@ static __always_inline __s32 inspect_handshake(__u8 *reader_index, const __u8 *p
 
     struct varint_value varint;
     // len 3 bytes varint max
-    MAX_VARINT_OR_DIE(varint, reader_index, payload_end, data_end, VARINT_SIZE((PACKET_ID_MAX + HANDSHAKE_DATA_MAX)));
+    MAX_VARINT_OR_DIE(varint, reader_index, payload_end, VARINT_SIZE((PACKET_ID_MAX + HANDSHAKE_DATA_MAX)));
     ASSERT_IN_RANGE(varint.value, (PACKET_ID_MIN + HANDSHAKE_DATA_MIN), (PACKET_ID_MAX + HANDSHAKE_DATA_MAX));
     // packet id
-    MAX_VARINT_OR_DIE(varint, reader_index, payload_end, data_end, VARINT_SIZE(0x00));
+    MAX_VARINT_OR_DIE(varint, reader_index, payload_end, VARINT_SIZE(0x00));
     ASSERT_OR_RETURN(varint.value == 0x00); // packet id needs to be 0
     // protocol version
-    VARINT_OR_DIE(varint, reader_index, payload_end, data_end);
+    VARINT_OR_DIE(varint, reader_index, payload_end);
     *protocol_version = varint.value;
     // host len
-    MAX_VARINT_OR_DIE(varint, reader_index, payload_end, data_end, VARINT_SIZE(HANDSHAKE_HOST_DATA_MAX));
+    MAX_VARINT_OR_DIE(varint, reader_index, payload_end, VARINT_SIZE(HANDSHAKE_HOST_DATA_MAX));
     ASSERT_IN_RANGE(varint.value, HANDSHAKE_HOST_DATA_MIN, HANDSHAKE_HOST_DATA_MAX);
     // read host
-    READ_OR_RETURN(reader_index, varint.value, payload_end, data_end);
+    READ_OR_RETURN(reader_index, varint.value, payload_end);
     // read port
-    READ_OR_RETURN(reader_index, 2, payload_end, data_end);
+    READ_OR_RETURN(reader_index, 2, payload_end);
     // intention
-    MAX_VARINT_OR_DIE(varint, reader_index, payload_end, data_end, VARINT_SIZE(3));
+    MAX_VARINT_OR_DIE(varint, reader_index, payload_end, VARINT_SIZE(3));
     __s32 intention = varint.value;
     __u8 support_transfer = *protocol_version >= 766;
 


### PR DESCRIPTION
## Summary

- Remove redundant `data_end` bounds checks from all TCP payload inspection macros and functions
- Since `tcp_payload_end <= data_end` is validated once in `minecraft_filter.c` before any inspection function is called, subsequent bounds checks only need to verify against `payload_end`
- The eBPF verifier understands that if `payload_end <= data_end` was already proven, then `ptr <= payload_end` implies `ptr <= data_end` transitively
- Added underflow guard for `ip_tot_len` subtraction to prevent u16 wrap-around that could bypass the `data_end` check

### Changed files
- **common.h**: Removed `dend` parameter from `CHECK_BOUNDS_OR_RETURN`, `READ_OR_RETURN`, `READ_VAL_OR_RETURN`, `VARINT_OR_DIE`, `MAX_VARINT_OR_DIE`
- **minecraft_helper.h**: Removed `dend` parameter from `VARINT_BYTE` macro and `read_varint_sized` function
- **minecraft_networking.h**: Removed `data_end` parameter from `inspect_handshake`, `inspect_status_request`, `inspect_ping_request`, `inspect_login_packet`
- **minecraft_filter.c**: Updated all call sites; added `ip_tot_len` underflow guard

## Test plan
- [ ] Verify eBPF program loads successfully with the verifier
- [ ] Test with Minecraft client connections (handshake, status, login, ping flows)
- [ ] Confirm no out-of-bounds access occurs under malformed packets