### PR TITLE
harden packet validation: drop fragments, SYN payload, SYN+FIN/RST

### DIFF
--- a/c/minecraft_filter.c
+++ b/c/minecraft_filter.c
@@ -50,7 +50,6 @@ struct
     __uint(max_entries, 65535);
     __type(key, struct ipv4_flow_key);  // flow key
     __type(value, struct player_entry); // idle timer + packet counter
-    __uint(pinning, LIBBPF_PIN_BY_NAME);
 } player_connection_map SEC(".maps");
 
 /*
@@ -88,7 +87,6 @@ struct
     __uint(max_entries, 65535);
     __type(key, __u32);                   // ipv4 address
     __type(value, struct throttle_entry); // window timer + hit counter
-    __uint(pinning, LIBBPF_PIN_BY_NAME);
 } connection_throttle SEC(".maps");
 
 // while connection_throttle is full, only retry inserting after this long
@@ -127,7 +125,6 @@ struct
     __uint(max_entries, 1);
     __type(key, __u32);
     __type(value, struct statistics);
-    __uint(pinning, LIBBPF_PIN_BY_NAME);
 } stats_map SEC(".maps");
 
 static __always_inline __u8 detect_tcp_bypass(const struct tcphdr *tcp)

--- a/c/minecraft_filter.c
+++ b/c/minecraft_filter.c
@@ -27,7 +27,7 @@ volatile const __u8 ONLINE_NAMES = 1;
 struct
 {
     __uint(type, BPF_MAP_TYPE_LRU_HASH);
-    __uint(max_entries, 4096);           // max amount of 4096 concurrent initial connections
+    __uint(max_entries, 16384);          // max amount of 16384 concurrent initial connections
     __type(key, struct ipv4_flow_key);   // flow key
     __type(value, struct initial_state); // initial state
 } conntrack_map SEC(".maps");
@@ -134,6 +134,7 @@ static __always_inline __u8 detect_tcp_bypass(const struct tcphdr *tcp)
 {
     if ((!tcp->syn && !tcp->ack && !tcp->fin && !tcp->rst) || // no SYN/ACK/FIN/RST flag
         (tcp->syn && tcp->ack) ||                             // SYN+ACK from external (unexpected)
+        (tcp->syn && (tcp->fin || tcp->rst)) ||               // SYN+FIN/SYN+RST never occur legitimately
         tcp->urg)
     { // drop if URG flag is set
         return 1;
@@ -212,6 +213,16 @@ __s32 minecraft_filter(struct xdp_md *ctx)
         return XDP_PASS;
     }
 
+    // drop fragmented tcp packets (MF flag or fragment offset set): non-first
+    // fragments carry no tcp header so the port check below would run on
+    // payload bytes, and after kernel reassembly the backend would receive
+    // data the state machine never inspected. Legitimate tcp does not
+    // fragment, the MSS keeps segments below the MTU
+    if (ip->frag_off & bpf_htons(0x3FFF))
+    {
+        return XDP_DROP;
+    }
+
     const struct tcphdr *tcp = (const void *)ip + (ip->ihl * 4);
     if ((const void *)(tcp + 1) > data_end)
     {
@@ -264,6 +275,13 @@ __s32 minecraft_filter(struct xdp_md *ctx)
     if (tcp->syn)
     {
         count_stats(stats_ptr, SYN_RECEIVE, 1);
+        // drop SYNs carrying payload (e.g. TCP fast open): the data would
+        // reach the backend without ever passing the inspection state machine
+        if (bpf_ntohs(ip->tot_len) > (ip->ihl * 4) + tcp_hdr_len)
+        {
+            count_stats(stats_ptr, TCP_BYPASS, 1);
+            goto drop;
+        }
         if(HIT_COUNT) {
             // connection throttle, fully in kernel: every source ip gets its
             // own window of HIT_COUNT_RESET_NS, opened by its first SYN and

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use log::LevelFilter;
 use log::debug;
 use log::warn;
 use log::{error, info};
-use prometheus::{IntGauge, register_int_gauge};
+use prometheus::{IntCounter, register_int_counter};
 use signal_hook::consts::TERM_SIGNALS;
 use signal_hook::iterator::Signals;
 use std::path::Path;
@@ -52,25 +52,25 @@ use config::Config;
 const STATS_TRACKING_CYCLE: u64 = 10; // every 10 seconds
 
 lazy_static! {
-    static ref INCOMING_BYTES: IntGauge =
-        register_int_gauge!("minecraft_incoming_bytes", "Total incoming bytes").unwrap();
-    static ref DROPPED_BYTES: IntGauge =
-        register_int_gauge!("minecraft_dropped_bytes", "Total dropped bytes").unwrap();
-    static ref VERIFIED: IntGauge = register_int_gauge!(
+    static ref INCOMING_BYTES: IntCounter =
+        register_int_counter!("minecraft_incoming_bytes", "Total incoming bytes").unwrap();
+    static ref DROPPED_BYTES: IntCounter =
+        register_int_counter!("minecraft_dropped_bytes", "Total dropped bytes").unwrap();
+    static ref VERIFIED: IntCounter = register_int_counter!(
         "minecraft_verified_connections",
         "Total verified connections"
     )
     .unwrap();
-    static ref DROPPED_PACKETS: IntGauge =
-        register_int_gauge!("minecraft_dropped_packets", "Total dropped packets").unwrap();
-    static ref STATE_SWITCHES: IntGauge =
-        register_int_gauge!("minecraft_state_switches", "Total state switches").unwrap();
-    static ref DROP_CONNECTION: IntGauge =
-        register_int_gauge!("minecraft_dropped_connections", "Total dropped connections").unwrap();
-    static ref SYN: IntGauge =
-        register_int_gauge!("minecraft_syn_packets", "Total SYN packets").unwrap();
-    static ref TCP_BYPASS: IntGauge =
-        register_int_gauge!("minecraft_tcp_bypass", "Total TCP bypass attempts").unwrap();
+    static ref DROPPED_PACKETS: IntCounter =
+        register_int_counter!("minecraft_dropped_packets", "Total dropped packets").unwrap();
+    static ref STATE_SWITCHES: IntCounter =
+        register_int_counter!("minecraft_state_switches", "Total state switches").unwrap();
+    static ref DROP_CONNECTION: IntCounter =
+        register_int_counter!("minecraft_dropped_connections", "Total dropped connections").unwrap();
+    static ref SYN: IntCounter =
+        register_int_counter!("minecraft_syn_packets", "Total SYN packets").unwrap();
+    static ref TCP_BYPASS: IntCounter =
+        register_int_counter!("minecraft_tcp_bypass", "Total TCP bypass attempts").unwrap();
 }
 
 fn setup_logger() -> Result<(), anyhow::Error> {
@@ -410,15 +410,19 @@ fn track_stats(
             total.drop_connection,
         );
 
-        // Update Prometheus metrics
-        INCOMING_BYTES.set(total.incoming_bytes as i64);
-        DROPPED_BYTES.set(total.dropped_bytes as i64);
-        VERIFIED.set(total.verified as i64);
-        DROPPED_PACKETS.set(total.dropped_packets as i64);
-        STATE_SWITCHES.set(total.state_switches as i64);
-        DROP_CONNECTION.set(total.drop_connection as i64);
-        SYN.set(total.syn as i64);
-        TCP_BYPASS.set(total.tcp_bypass as i64);
+        // Update Prometheus metrics. The map totals are cumulative for the
+        // lifetime of this process (the unpinned stats map dies with the
+        // loader), so publish the delta since the last cycle to keep proper
+        // counter semantics; on restart both reset together, which Prometheus
+        // handles as a regular counter reset.
+        INCOMING_BYTES.inc_by(total.incoming_bytes.saturating_sub(INCOMING_BYTES.get()));
+        DROPPED_BYTES.inc_by(total.dropped_bytes.saturating_sub(DROPPED_BYTES.get()));
+        VERIFIED.inc_by(total.verified.saturating_sub(VERIFIED.get()));
+        DROPPED_PACKETS.inc_by(total.dropped_packets.saturating_sub(DROPPED_PACKETS.get()));
+        STATE_SWITCHES.inc_by(total.state_switches.saturating_sub(STATE_SWITCHES.get()));
+        DROP_CONNECTION.inc_by(total.drop_connection.saturating_sub(DROP_CONNECTION.get()));
+        SYN.inc_by(total.syn.saturating_sub(SYN.get()));
+        TCP_BYPASS.inc_by(total.tcp_bypass.saturating_sub(TCP_BYPASS.get()));
         drop(stats); // release lock before waiting
 
         let guard = dummy_mutex


### PR DESCRIPTION
- drop fragmented tcp packets: non-first fragments have no tcp header, so the port check ran on payload bytes and reassembled data could reach the backend without passing the inspection state machine
- drop SYNs carrying payload (TCP fast open style), the data would bypass payload inspection
- drop SYN+FIN and SYN+RST flag combinations in detect_tcp_bypass
- bump conntrack_map to 16384 entries to reduce LRU eviction of legitimate in-flight handshakes during floods